### PR TITLE
Update Liquidsoap image to Ubuntu 20.04

### DIFF
--- a/liquidsoap/Dockerfile
+++ b/liquidsoap/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER Kassim Benhaddad
 
 # Install services


### PR DESCRIPTION
This updates the Liquidsoap base image to Ubuntu 20.04 from 18.04.

This is due to changes in new Liquidsoap version that require packages not available in the 18.04 repos.