### PR TITLE
Add mopidy healthcheck

### DIFF
--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod +x /opt/mpc_pause_check.sh
 
 USER mopidy
 
-HEALTHCHECK --interval=5m --timeout=30s CMD sh /opt/mpc_pause_check.sh
+HEALTHCHECK --interval=60s --timeout=30s CMD sh /opt/mpc_pause_check.sh
 
 EXPOSE 6680
 

--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -36,7 +36,13 @@ RUN apt-get purge --auto-remove -y \
 
 COPY mopidy.conf /var/lib/mopidy/.config/mopidy/mopidy.conf
 
+COPY mpc_pause_check.sh /opt/
+
+RUN chmod +x /opt/mpc_pause_check.sh
+
 USER mopidy
+
+HEALTHCHECK --interval=5m --timeout=30s CMD sh /opt/mpc_pause_check.sh
 
 EXPOSE 6680
 

--- a/mopidy/mpc_pause_check.sh
+++ b/mopidy/mpc_pause_check.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-MPC_CURRENT_TIME=`mpc status | awk '/^\[playing\]/ { sub(/\/.+/,"",$3); split($3,a,/:/); print a[1]*60+a[2] }'`
+if mpc | grep playing;
+then
+	MPC_CURRENT_TIME=`mpc status | awk '/^\[playing\]/ { sub(/\/.+/,"",$3); split($3,a,/:/); print a[1]*60+a[2] }'`
 
-sleep 10
+	sleep 10
 
-MPC_NEW_TIME=`mpc status | awk '/^\[playing\]/ { sub(/\/.+/,"",$3); split($3,a,/:/); print a[1]*60+a[2] }'`
+	MPC_NEW_TIME=`mpc status | awk '/^\[playing\]/ { sub(/\/.+/,"",$3); split($3,a,/:/); print a[1]*60+a[2] }'`
 
-if [ "$MPC_CURRENT_TIME" == "$MPC_NEW_TIME" ]; then mpc next; fi
+	if [ "$MPC_CURRENT_TIME" == "$MPC_NEW_TIME" ]; then mpc next; fi
+fi

--- a/mopidy/mpc_pause_check.sh
+++ b/mopidy/mpc_pause_check.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+MPC_CURRENT_TIME=`mpc status | awk '/^\[playing\]/ { sub(/\/.+/,"",$3); split($3,a,/:/); print a[1]*60+a[2] }'`
+
+sleep 10
+
+MPC_NEW_TIME=`mpc status | awk '/^\[playing\]/ { sub(/\/.+/,"",$3); split($3,a,/:/); print a[1]*60+a[2] }'`
+
+if [ "$MPC_CURRENT_TIME" == "$MPC_NEW_TIME" ]; then mpc next; fi


### PR DESCRIPTION
This PR introduces a bash script that checks the status of mopidy every minute using the `mpc` command.

It will get the currently playing song time, wait 10 seconds, and then check the currently playing time again. If they are the same, then mopidy has stalled and it will run `mpc next` to start playing the next track.

The script is run via Docker's healthcheck function. The script always returns `0` though, so it will not restart the container.

I've tested this for a week of continuous play and mopidy has not stalled in this time.,