### PR TITLE
Change sh to bash for mopidy healthcheck

### DIFF
--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod +x /opt/mpc_pause_check.sh
 
 USER mopidy
 
-HEALTHCHECK --interval=60s --timeout=30s CMD sh /opt/mpc_pause_check.sh
+HEALTHCHECK --interval=60s --timeout=30s CMD bash /opt/mpc_pause_check.sh
 
 EXPOSE 6680
 


### PR DESCRIPTION
This changes the script to use bash instead of sh, as it was causing
issues with the healthcheck not running because of missing features.