### PR TITLE
Fix for now playing API update

### DIFF
--- a/frontend/src/components/useSaveTrack.jsx
+++ b/frontend/src/components/useSaveTrack.jsx
@@ -15,7 +15,7 @@ const useSaveTrack = (track, artist, key) => {
       if (data.results[0] && data.results[0].wrapperType === "track") {
         const apiUrl = `https://cors-anywhere.herokuapp.com/https://api.song.link/page?url=https://song.link/i/${data.results[0].trackId}`;
         getApi(apiUrl).then((streamingServices) => {
-          if (streamingServices.inputMatchData.matches) {
+          if (streamingServices && streamingServices.inputNodeUniqueId) {
             Object.entries(streamingServices.nodesByUniqueId).map((node) => {
               if (node[0].includes("AUTOMATED_LINK")) {
                 if (node[1].matchNodeUniqueId) {


### PR DESCRIPTION

This fixes an issue with the now playing API, that was caused due to
`inputMatchData` being changed to `inputNodeUniqueId` in the API response.