### PR TITLE
Add fixes for audio not playing correctly

### DIFF
--- a/frontend/src/components/Container.jsx
+++ b/frontend/src/components/Container.jsx
@@ -23,6 +23,7 @@ const Container = () => {
   const [logoSpinning, setLogoSpinning] = useState(false);
   const [modal, setModal] = useState();
   const [showVisualiser, setShowVisualiser] = useState(false);
+  const [showVisualiser, setShowVisualiser] = useState(false);
   const [player, setPlayer] = useState();
 
   const EmbedCode = () => {
@@ -30,13 +31,13 @@ const Container = () => {
     const handleToggle = () => setShow(!show);
 
     return (
-      <Box mt="auto" pt={2} mb={3} mx={2}>
+      <Box mt='auto' pt={2} mb={3} mx={2}>
         <Collapse isOpen={show}>
-          <Code my={2} p={2} overflow="auto">
+          <Code my={2} p={2} overflow='auto'>
             {`<iframe src = '${window.location.protocol}//${window.location.host}/embed' frameborder = '0' allowtransparency = 'true' style = 'width: 100%; min-height: 150px; border: 0;'></iframe>`}
           </Code>
         </Collapse>
-        <Button variantColor="blue" variant="link" onClick={handleToggle}>
+        <Button variantColor='blue' variant='link' onClick={handleToggle}>
           Embed player
         </Button>
       </Box>
@@ -47,41 +48,41 @@ const Container = () => {
     <Fragment>
       <VisualiserProvider value={{ player, setPlayer }}>
         <Box
-          width="100%"
-          minHeight="100vh"
+          width='100%'
+          minHeight='100vh'
           bg={colorMode === "light" ? "#99c0ff" : "#1a202c"}
           color={colorMode === "light" ? "black" : "white"}
         >
           {player && (
-            <Box pos="absolute" bottom={0} left={0} pointerEvents="none">
+            <Box pos='absolute' bottom={0} left={0} pointerEvents='none'>
               <Collapse isOpen={showVisualiser}>
                 <Visualisation audio={player.current} />
               </Collapse>
             </Box>
           )}
           <Flex
-            direction="column"
-            justify="flex-start"
-            align="center"
-            width="100%"
-            maxWidth="960px"
-            minHeight="100vh"
-            mx="auto"
+            direction='column'
+            justify='flex-start'
+            align='center'
+            width='100%'
+            maxWidth='960px'
+            minHeight='100vh'
+            mx='auto'
             pt={5}
-            pos="relative"
+            pos='relative'
             zindex={1}
           >
             <PseudoBox
               as={colorMode === "light" ? FaMoon : FaSun}
-              size="30px"
+              size='30px'
               onClick={toggleColorMode}
               color={color[colorMode]}
             />
             <Box px={5}>
               <Image
-                src="/logo512.png"
-                maxWidth="230px"
-                mx="auto"
+                src='/logo512.png'
+                maxWidth='230px'
+                mx='auto'
                 mt={3}
                 className={logoSpinning ? "icon-spin" : ""}
                 onClick={() =>
@@ -94,7 +95,7 @@ const Container = () => {
               <Links />
               <Button
                 mt={2}
-                variant="link"
+                variant='link'
                 onClick={() => setShowVisualiser(!showVisualiser)}
               >
                 Visualiser
@@ -104,8 +105,8 @@ const Container = () => {
             <Text mb={3}>
               Powered by{" "}
               <Link
-                href="https://github.com/MrLemur/bottle-radio"
-                color="teal.500"
+                href='https://github.com/MrLemur/bottle-radio'
+                color='teal.500'
                 isExternal
               >
                 Bottle Radio

--- a/frontend/src/components/Contexts.jsx
+++ b/frontend/src/components/Contexts.jsx
@@ -9,4 +9,4 @@ export const ModalConsumer = ModalContext.Consumer;
 export const VisualiserProvider = VisualiserContext.Provider;
 export const VisualiserConsumer = VisualiserContext.Consumer;
 
-export  {ModalContext, VisualiserContext};
+export { ModalContext, VisualiserContext };

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -53,7 +53,7 @@ const Player = () => {
 
   useEffect(() => {
     const audio = document.getElementById("player");
-    if (audio) {
+    if (!audio.paused) {
       setPlayer(audioRef);
     }
   }, [setPlayer]);
@@ -117,23 +117,23 @@ const Player = () => {
             onClose();
             setModal();
           }}
-          size="sm"
+          size='sm'
           isCentered
         >
           <ModalOverlay />
           <ModalContent>
             <ModalCloseButton />
             <ModalBody>
-              <Grid templateColumns="1fr 1fr" justifyItems="center" gap={0}>
+              <Grid templateColumns='1fr 1fr' justifyItems='center' gap={0}>
                 {modal ? (
                   modal.map((link) => (
                     <Link key={link.url} href={link.url} isExternal>
-                      <Button variant="ghost">{link.displayName}</Button>
+                      <Button variant='ghost'>{link.displayName}</Button>
                     </Link>
                   ))
                 ) : (
                   <div>
-                    <Spinner size="sm" /> Loading...
+                    <Spinner size='sm' /> Loading...
                   </div>
                 )}
               </Grid>
@@ -147,38 +147,38 @@ const Player = () => {
   return (
     <div>
       <Flex
-        direction="column"
-        justify="center"
-        align="center"
-        width="100%"
-        height="100%"
+        direction='column'
+        justify='center'
+        align='center'
+        width='100%'
+        height='100%'
       >
         <Box>
           <Grid
             m={2}
             p={2}
-            templateColumns="auto 1fr auto"
-            alignItems="center"
+            templateColumns='auto 1fr auto'
+            alignItems='center'
             gap={1}
           >
             <PseudoBox
-              gridRow="1/4"
-              size="80px"
-              aria-label="Play toggle"
+              gridRow='1/4'
+              size='80px'
+              aria-label='Play toggle'
               as={loading ? FaSpinner : playing ? FaPauseCircle : FaPlayCircle}
               onClick={togglePlay}
               _hover={{ color: colorHover[colorMode] }}
               mr={1}
               className={loading ? "icon-spin" : ""}
             />
-            <Text m={0} align="right">
+            <Text m={0} align='right'>
               <strong>{nowPlaying[0]}</strong>
             </Text>
-            <Text m={0} align="right">
+            <Text m={0} align='right'>
               {nowPlaying[1]}
             </Text>
 
-            <Flex direction="row" justify="center" maxWidth={400} p={2}>
+            <Flex direction='row' justify='center' maxWidth={400} p={2}>
               <Slider
                 defaultValue={100}
                 min={0}
@@ -188,13 +188,13 @@ const Player = () => {
                 width={80}
               >
                 <SliderTrack />
-                <SliderFilledTrack bg="tomato" />
+                <SliderFilledTrack bg='tomato' />
                 <SliderThumb size={2} />
               </Slider>
-              <Box size="20px" as={muted ? FaVolumeMute : FaVolumeUp} ml={3} />
+              <Box size='20px' as={muted ? FaVolumeMute : FaVolumeUp} ml={3} />
               <audio
-                id="player"
-                crossorigin="anonymouse"
+                id='player'
+                crossorigin='anonymouse'
                 ref={audioRef}
                 autoPlay
                 onPlay={() => setPlaying(true)}
@@ -204,19 +204,19 @@ const Player = () => {
               >
                 <source
                   src={variables.REACT_ICECAST_URL + "radio.mp3"}
-                  type="audio/mp3"
+                  type='audio/mp3'
                 />
                 Your browser does not support the audio element.
               </audio>
             </Flex>
-            <Text gridColumn="1/4">
+            <Text gridColumn='1/4'>
               <strong>Listeners: </strong>
               {listeners[0]} <strong>Peak: </strong>
               {listeners[1]}
             </Text>
-            <Box gridColumn="3" gridRow="1/4" alignItems="center">
+            <Box gridColumn='3' gridRow='1/4' alignItems='center'>
               <PseudoBox
-                size="25px"
+                size='25px'
                 as={FaHeart}
                 mx={1}
                 onClick={onOpen}

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -38,6 +38,7 @@ const Player = () => {
   const [playing, setPlaying] = useState(false);
   const [loading, setLoading] = useState(false);
   const [muted, setMuted] = useState(false);
+  const [firstLoad, setFirstLoad] = useState(true);
   const [nowPlaying, setNowPlaying] = useState(["No data", "No data"]);
   const [listeners, setListeners] = useState([0, 0]);
   const { colorMode } = useColorMode();
@@ -53,7 +54,7 @@ const Player = () => {
 
   useEffect(() => {
     const audio = document.getElementById("player");
-    if (!audio.paused) {
+    if (audio) {
       setPlayer(audioRef);
     }
   }, [setPlayer]);
@@ -84,6 +85,9 @@ const Player = () => {
 
   const togglePlay = () => {
     let player = document.getElementById("player");
+    if (firstLoad) {
+      setFirstLoad(false);
+    }
     if (player.paused) {
       setPlaying(true);
       player.load();
@@ -194,13 +198,18 @@ const Player = () => {
               <Box size='20px' as={muted ? FaVolumeMute : FaVolumeUp} ml={3} />
               <audio
                 id='player'
-                crossorigin='anonymouse'
-                ref={audioRef}
+                crossorigin='anonymous'
                 autoPlay
+                preload='none'
+                ref={audioRef}
                 onPlay={() => setPlaying(true)}
                 onPause={() => setPlaying(false)}
-                onLoadStart={() => setLoading(true)}
-                onLoadedData={() => setLoading(false)}
+                onLoadStart={() => {
+                  if (!firstLoad) {
+                    setLoading(true);
+                  }
+                }}
+                onCanPlay={() => setLoading(false)}
               >
                 <source
                   src={variables.REACT_ICECAST_URL + "radio.mp3"}

--- a/frontend/src/components/Visualisation.jsx
+++ b/frontend/src/components/Visualisation.jsx
@@ -52,6 +52,12 @@ const Visualisation = (props) => {
         }
       };
       renderFrame();
+      document.documentElement.addEventListener("mousedown", function () {
+        if (context.state !== "running") {
+          console.log("AudioContext starting due to user input");
+          context.resume();
+        }
+      });
     };
     renderVisualisation();
   }, [props.audio]);


### PR DESCRIPTION

This adds a check to AudioContext to only load once user presses on the page.

It also adds a check for first load of the page to not show the loading symbol when autoplay doesn't work.

This has an issues on browsers that do autoplay, as the stream will load anyway. If the user clicks play, it will load the stream again.

This has been decided as a good compromise.