### PR TITLE
liquidsoap default is now main, not master

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       - "traefik.http.routers.mopidy.middlewares=mopidy_auth@docker"
 
   liquidsoap:
-    image: savonet/liquidsoap:master
+    image: savonet/liquidsoap:main
     environment:
       - LIQUIDSOAP_DJ_USERNAME=${LIQUIDSOAP_DJ_USERNAME}
       - LIQUIDSOAP_DJ_PASSWORD=${LIQUIDSOAP_DJ_PASSWORD}

--- a/liquidsoap/Dockerfile
+++ b/liquidsoap/Dockerfile
@@ -1,4 +1,4 @@
-FROM savonet/liquidsoap:master
+FROM savonet/liquidsoap:main
 
 EXPOSE 8005 8010
 


### PR DESCRIPTION
I noticed the liquidsoap master branch changed to main
- savonet/liquidsoap:main
- https://hub.docker.com/r/savonet/liquidsoap/tags?page=1&ordering=last_updated