### PR TITLE
Add Go server to centralise now playing data to frontend

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,7 +2,6 @@ DOMAIN=[example.com]
 LETSENCRYPT_EMAIL=[email where you can be reached incase of SSL cert issues]
 
 REACT_ICECAST_URL=[https://stream.example.com/]
-REACT_KEY=[a random string of numbers to make now playing API work]
 
 LIQUIDSOAP_DJ_USERNAME=[username for live broadcast]
 LIQUIDSOAP_DJ_PASSWORD=[password for live broadcast]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store*
 .env
 letsencrypt/*
+frontend/song-links/song-links.json

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,11 @@
+# Build go binary
+FROM golang:1.17-alpine as go_builder
+WORKDIR /app
+COPY song-links/main.go .
+COPY song-links/go.mod .
+RUN go build -ldflags="-s -w"
+RUN chmod +x song-links
+
 # => Build container
 FROM node:16-alpine as builder
 WORKDIR /app
@@ -13,8 +21,11 @@ FROM caddy/caddy
 # Static build
 COPY --from=builder /app/build /usr/share/caddy/
 
+# Copy Go songs-link binary
+COPY --from=go_builder /app/song-links /usr/local/bin/
+
 # Default port exposure
-EXPOSE 80
+EXPOSE 80 10000
 
 # Copy .env file and shell script to container
 WORKDIR /usr/share/caddy/
@@ -23,10 +34,13 @@ COPY ./env.sh .
 # Add bash
 RUN apk add --no-cache bash
 
+# Add entrypoint.sh
+COPY ./entrypoint.sh /etc/
+
 # Make our shell script executable
 RUN chmod +x env.sh
 
 RUN printf ':80 \nroot * /usr/share/caddy \nfile_server \ntry_files {path} /index.html \nencode gzip' > /etc/caddy/Caddyfile
 
 # Start Caddy
-CMD ["/bin/bash", "-c", "/usr/share/caddy/env.sh && caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]
+CMD ["/etc/entrypoint.sh"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+/usr/share/caddy/env.sh
+song-links &
+caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/frontend/song-links/go.mod
+++ b/frontend/song-links/go.mod
@@ -1,0 +1,3 @@
+module song-links
+
+go 1.17

--- a/frontend/song-links/main.go
+++ b/frontend/song-links/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+type link struct {
+	Type        string `json:"type"`
+	DisplayName string `json:"displayName"`
+	URL         string `json:"url"`
+}
+
+func handleRequests() {
+	http.HandleFunc("/", saveLinks)
+	log.Fatal(http.ListenAndServe(":10000", nil))
+}
+
+// getItunesID returns the iTunes ID for a song.
+// @param {string} title - The title of the song.
+// @param {string} artist - The artist of the song.
+// @return {string, error} - The iTunes ID for the song or and error.
+func getItunesID(title string, artist string) (int32, error) {
+	type result struct {
+		WrapperType string `json:"wrapperType"`
+		TrackID     int32  `json:"trackId"`
+	}
+
+	type resultList struct {
+		ResultCount int      `json:"resultCount"`
+		Results     []result `json:"results"`
+	}
+
+	searchTerm := url.QueryEscape(title + " " + artist)
+
+	url := fmt.Sprintf("https://itunes.apple.com/search?term=%s&limit=3country=IE&entity=song&limit=5", searchTerm)
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	results := resultList{}
+	json.Unmarshal(body, &results)
+
+	if results.ResultCount == 0 || results.Results[0].WrapperType != "track" {
+		return 0, fmt.Errorf("No results found")
+	}
+	return results.Results[0].TrackID, nil
+}
+
+// getSongLinks returns the links from a song from song.link website
+// @param {string} title - The title of the song.
+// @param {string} artist - The artist of the song.
+// @return {[]byte, error} - Byte JSON of the links or an error.
+func getSongLinks(title string, artist string) ([]link, error) {
+
+	itunesID, err := getItunesID(title, artist)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("https://api.song.link/v1-alpha.1/links?platform=itunes&type=song&userCountry=GB&id=%d", itunesID)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var linksJSON map[string]interface{}
+	json.Unmarshal(body, &linksJSON)
+
+	var links []link
+
+	for name, linkData := range linksJSON["linksByPlatform"].(map[string]interface{}) {
+		linkData := linkData.(map[string]interface{})
+		links = append(links, link{Type: "listen", DisplayName: fixDisplayName(name), URL: linkData["url"].(string)})
+	}
+
+	return links, nil
+
+}
+
+// saveLinks handles the HTTP request to get song links and saves it to the local filesystem.
+func saveLinks(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	fmt.Println(r.Header)
+	query := r.URL.Query()
+	title := query.Get("title")
+	artist := query.Get("artist")
+	links, err := getSongLinks(title, artist)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// write links to file
+	file, _ := json.MarshalIndent(links, "", "  ")
+	//write file to disk
+	err = ioutil.WriteFile("song-links.json", file, 0644)
+
+	fmt.Fprintf(w, "SUCCESS")
+}
+
+func main() {
+	handleRequests()
+}
+
+func fixDisplayName(displayName string) string {
+	regex := regexp.MustCompile("([A-Z])")
+	addSpace := regex.ReplaceAllString(displayName, " $1")
+	return strings.Title(addSpace)
+}

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -45,8 +45,7 @@ const Player = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const trackLinks = useSaveTrack(
     nowPlaying[0],
-    nowPlaying[1],
-    variables.REACT_KEY
+    nowPlaying[1]
   );
   const audioRef = useRef(null);
   const { setPlayer } = useContext(VisualiserContext);

--- a/frontend/src/components/useSaveTrack.jsx
+++ b/frontend/src/components/useSaveTrack.jsx
@@ -1,47 +1,26 @@
 import { useState, useEffect } from "react";
 
-const displayNameFix = (name) => {
-  let result = name.replace(/([A-Z])/g, " $1");
-  let finalResult = result.charAt(0).toUpperCase() + result.slice(1);
-  return finalResult;
-};
-
-const useSaveTrack = (track, artist, key) => {
+const useSaveTrack = (track, artist) => {
   const [trackList, setTrackList] = useState([]);
   const getApi = async (url) => {
     let response = await fetch(url);
     return await response.json();
   };
 
-  const searchUrl = `https://itunes.apple.com/search?term=${track} ${artist}&country=IE&entity=song&key=${key}`;
+  const hostURL = window.location.protocol + "//" + window.location.host;
+
+  const linksUrl = hostURL + "/song-links.json";
 
   useEffect(() => {
     if (track !== "No data" && artist !== "No data") {
-      let links = [];
-      getApi(searchUrl).then((data) => {
-        if (data.results[0] && data.results[0].wrapperType === "track") {
-          const apiUrl = `https://cors-anywhere.herokuapp.com/https://api.song.link/v1-alpha.1/links?platform=itunes&type=song&userCountry=GB&id=${data.results[0].trackId}`;
-          getApi(apiUrl).then((streamingServices) => {
-            if (streamingServices && streamingServices.linksByPlatform) {
-              Object.entries(streamingServices.linksByPlatform).map((node) => {
-                let url = node[1].url;
-                let displayName = displayNameFix(node[0]);
-                links.push({
-                  type: "listen",
-                  displayName: displayName,
-                  url: url,
-                });
-                return null;
-              });
-            }
-            setTrackList(links);
-          });
-        } else {
+      setTimeout(() => {
+        getApi(linksUrl).then((data) => {
+          setTrackList(data);
+        })
+      },3000)} else {
           setTrackList([]);
         }
-      });
-    }
-  }, [track, artist, searchUrl]);
+  }, [track, artist, linksUrl]);
   return trackList;
 };
 

--- a/liquidsoap/default.liq
+++ b/liquidsoap/default.liq
@@ -42,17 +42,29 @@ def from_live(jingle,old,new) =
   sequence([s,fade.initial(new)],merge=true)
 end
 
-jingle = audio_to_stereo(single("/etc/liquidsoap/jingle.mp3"))
-
-mopidy_stream = mksafe(audio_to_stereo(input.harbor("/mopidy", id = "mopidy_stream", port = 8010,  user = "mopidy", password = "mopidy", metadata_charset = "UTF-8", max = 30.0)))
-
 # Add missing metadata to live stream function
 def fix_live_metadata(m) =
   # Grab the current title
   title = m["title"]
+  artist = m["artist"]
   # Insert metadata if it is missing during live broadcast
   if title == "Unknown" or title == "" then [("title","Live Broadcast - This is a live broadcast")] else [("title",title)] end
 end
+
+def log_metadata(m) =
+  # Grab the current title and artist
+  metadata = string.split(separator="-",m["title"])
+  title = url.encode(string.trim(list.nth(default="", metadata, 0)))
+  artist = url.encode(string.trim(list.nth(default="", metadata, 1)))
+  ignore(http.head(timeout=0.5, "http://frontend:10000/?title=#{title}&artist=#{artist}"))
+  print("Sending metadata to frontend: #{title} by #{artist}")
+end
+
+jingle = audio_to_stereo(single("/etc/liquidsoap/jingle.mp3"))
+
+mopidy_stream = mksafe(audio_to_stereo(input.harbor("/mopidy", id = "mopidy_stream", port = 8010,  user = "mopidy", password = "mopidy", metadata_charset = "UTF-8", max = 30.0)))
+
+mopidy_stream = on_metadata(log_metadata, mopidy_stream)
 
 # Live Broadcasting
 live = audio_to_stereo(input.harbor("/", id = "live_streamer_input", port = 8005,  user = get_var("LIQUIDSOAP_DJ_USERNAME","dj"), password = get_var("LIQUIDSOAP_DJ_PASSWORD","dj"), metadata_charset = "UTF-8"))


### PR DESCRIPTION
This PR adds in a new Go server that runs in the frontend container.

Liquidsoap will send metadata changes to the server, which is responsible to finding song links and saving to a JSON file for the frontend app to read.